### PR TITLE
Improve Autoware Calibration Publisher

### DIFF
--- a/calibration_publisher/CMakeLists.txt
+++ b/calibration_publisher/CMakeLists.txt
@@ -5,11 +5,14 @@ find_package(autoware_build_flags REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   autoware_msgs
   cv_bridge
+  geometry_msgs
   image_transport
   roscpp
   sensor_msgs
   std_msgs
-  tf
+  tf2
+  tf2_geometry_msgs
+  tf2_ros
 )
 
 find_package(OpenCV REQUIRED)

--- a/calibration_publisher/package.xml
+++ b/calibration_publisher/package.xml
@@ -13,9 +13,12 @@
 
   <depend>autoware_msgs</depend>
   <depend>cv_bridge</depend>
+  <depend>geometry_msgs</depend>
   <depend>image_transport</depend>
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>tf</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2</depend>
 </package>


### PR DESCRIPTION
Transferred from gitlab, see original PR for details:
https://gitlab.com/autowarefoundation/autoware.ai/utilities/-/merge_requests/77

- Update to TF2
- Use static transform publisher for camera->lidar tf
- Only publish the Autoware projection matrix once since it never changes during runtime